### PR TITLE
fix: rename interfaces ts, simplified store

### DIFF
--- a/app/Http/Controllers/WhatsappTemplateController.php
+++ b/app/Http/Controllers/WhatsappTemplateController.php
@@ -3,40 +3,15 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use TCG\Voyager\Events\BreadDataAdded;
-use TCG\Voyager\Facades\Voyager;
 use TCG\Voyager\Http\Controllers\VoyagerBaseController;
 
 class WhatsappTemplateController extends VoyagerBaseController
 {
       public function store(Request $request)
       {
-            $slug = $this->getSlug($request);
-
-            $dataType = Voyager::model('DataType')->where('slug', '=', $slug)->first();
-            $request['status'] = 'Pendiente';
-            // Check permission
-            $this->authorize('add', app($dataType->model_name));
-
-            // Validate fields with ajax
-            $val = $this->validateBread($request->all(), $dataType->addRows)->validate();
-            $data = $this->insertUpdateData($request, $slug, $dataType->addRows, new $dataType->model_name());
-
-            event(new BreadDataAdded($dataType, $data));
-
-            if (!$request->has('_tagging')) {
-            if (auth()->user()->can('browse', $data)) {
-                  $redirect = redirect()->route("voyager.{$dataType->slug}.index");
-            } else {
-                  $redirect = redirect()->back();
-            }
-
-            return $redirect->with([
-                  'message'    => __('voyager::generic.successfully_added_new')." {$dataType->getTranslatedAttribute('display_name_singular')}",
-                  'alert-type' => 'success',
+            $request->merge([
+                  'status' => 'Pendiente'
             ]);
-            } else {
-            return response()->json(['success' => true, 'data' => $data]);
-            }
+            return parent::store($request);
       }
 }

--- a/resources/js/components/charts/BarChart.tsx
+++ b/resources/js/components/charts/BarChart.tsx
@@ -9,7 +9,7 @@ import {
     Legend,
 } from 'chart.js';
 import { Bar } from "react-chartjs-2";
-import { chartOptions } from "./Props";
+import { ChartOptions } from "./Props";
 
 ChartJS.register(
     CategoryScale,
@@ -20,7 +20,7 @@ ChartJS.register(
     Legend
 );
 
-const BarChart = (props: chartOptions) => {
+const BarChart = (props: ChartOptions) => {
     return (<Bar data={props.data} options={props.options} height={120} />)
 }
 

--- a/resources/js/components/charts/DoughnutChart.tsx
+++ b/resources/js/components/charts/DoughnutChart.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { Doughnut } from "react-chartjs-2";
-import { chartOptions } from "./Props";
+import { ChartOptions } from "./Props";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
-const DoughnutChart = (props: chartOptions) => {
+const DoughnutChart = (props: ChartOptions) => {
     return (<Doughnut data={props.data} options={props.options} height={100} />)
 }
 

--- a/resources/js/components/charts/LineChart.tsx
+++ b/resources/js/components/charts/LineChart.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Line } from "react-chartjs-2";
-import { chartOptions } from "./Props";
+import { ChartOptions } from "./Props";
 import {
     Chart as ChartJS,
     CategoryScale,
@@ -22,7 +22,7 @@ ChartJS.register(
     Legend
 );
 
-const LineChart = (props: chartOptions) => {
+const LineChart = (props: ChartOptions) => {
     return (<Line data={props.data} options={props.options} height={100} />)
 }
 

--- a/resources/js/components/charts/PieChart.tsx
+++ b/resources/js/components/charts/PieChart.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { Pie } from "react-chartjs-2";
-import { chartOptions } from "./Props";
+import { ChartOptions } from "./Props";
 
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
-const PieChart = (props: chartOptions) => {
+const PieChart = (props: ChartOptions) => {
     return (<Pie data={props.data} options={props.options} />)
 }
 

--- a/resources/js/components/charts/Props.tsx
+++ b/resources/js/components/charts/Props.tsx
@@ -1,7 +1,7 @@
-export interface chartOptions {
+export interface ChartOptions {
     data: {
         labels: Array<string>,
-        datasets: Array<chartData>
+        datasets: Array<ChartData>
     },
     options: {
         responsive: boolean,
@@ -14,7 +14,7 @@ export interface chartOptions {
     }
 }
 
-export interface chartData {
+export interface ChartData {
     label: string,
     data: Array<number>,
     backgroundColor: Array<string>,

--- a/resources/js/pages/customers/Customers.tsx
+++ b/resources/js/pages/customers/Customers.tsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import Personal from './components/Personal';
 import Tax from './components/Tax';
 import User from './components/User';
-import { IState } from './props/props';
+import { Customer } from './Props';
 import Step from './components/Step';
 import './styles.scss';
 
@@ -16,7 +16,7 @@ const customer = app?.getAttribute('data-customer');
 
 const Customers = () => {
 
-    const [state, setState] = useState<IState>({
+    const [state, setState] = useState<Customer>({
         api_token: api_token,
         _token: csrf,
         id: 0,
@@ -38,7 +38,7 @@ const Customers = () => {
     useEffect(() => {
         if (edit == "1") {
             try {
-                let data: IState = JSON.parse(customer ?? "{}");
+                let data: Customer = JSON.parse(customer ?? "{}");
                 setState((prevState) => {
                     return { ...prevState, ...data };
                 });
@@ -50,7 +50,7 @@ const Customers = () => {
 
     const [step, setStep] = useState<number>(1);
 
-    const updateFields = (fields: Partial<IState>) => {
+    const updateFields = (fields: Partial<Customer>) => {
         setState(state => {
             return { ...state, ...fields }
         })

--- a/resources/js/pages/customers/Props.ts
+++ b/resources/js/pages/customers/Props.ts
@@ -1,4 +1,4 @@
-export interface IState {
+export interface Customer {
     api_token: any,
     _token: any,
     id: number,
@@ -20,6 +20,6 @@ export interface IState {
 export interface IProps {
     nextStep: Function,
     prevStep: Function,
-    handleChange: (fields: Partial<IState>) => void,
-    values: Partial<IState>
+    handleChange: (fields: Partial<Customer>) => void,
+    values: Partial<Customer>
 }

--- a/resources/js/pages/customers/components/Personal.tsx
+++ b/resources/js/pages/customers/components/Personal.tsx
@@ -1,5 +1,5 @@
 import React, {SyntheticEvent} from "react";
-import { IProps } from "../props/props";
+import { IProps } from "../Props";
 
 const Personal = (props: IProps) => {
 

--- a/resources/js/pages/customers/components/Tax.tsx
+++ b/resources/js/pages/customers/components/Tax.tsx
@@ -1,5 +1,5 @@
 import React, { SyntheticEvent } from "react";
-import { IProps } from "../props/props";
+import { IProps } from "../Props";
 
 const Tax = (props: IProps) => {
 

--- a/resources/js/pages/customers/components/User.tsx
+++ b/resources/js/pages/customers/components/User.tsx
@@ -1,5 +1,5 @@
 import React, { SyntheticEvent } from "react";
-import { IProps } from "../props/props";
+import { IProps } from "../Props";
 import axios from 'axios';
 
 const User = (props: IProps) => {

--- a/resources/js/pages/dashboard/Props.ts
+++ b/resources/js/pages/dashboard/Props.ts
@@ -1,9 +1,9 @@
-import { chartData } from "../../components/charts/Props";
+import { ChartData } from "../../components/charts/Props";
 
 export interface dashboardState {
     count_example: number,
     data_example: {
         labels: Array<string>,
-        datasets: Array<chartData>
+        datasets: Array<ChartData>
     },
 }


### PR DESCRIPTION
Interfaces de typescript renombradas, metodo store del controlador de templates de whatsapp simplificado para no tener tanto codigo